### PR TITLE
added ur username xP

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "icon": "icon.png",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yourusername/cursor-oled-1600nits.git"
+    "url": "https://github.com/redpredator8/cursor-oled-1600nits.git"
   },
   "keywords": [
     "theme",


### PR DESCRIPTION
because on the market place https://marketplace.visualstudio.com/items?itemName=redpredator8.cursor-oled-1600nits
the repo links doesnt work. it still had the placeholder name